### PR TITLE
Fix the plugin options not being merged and parsed correctly

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -19,7 +19,7 @@ parseOptions = (opts) ->
 
 module.exports = (bumped, plugin, cb) ->
   changelog = path.resolve plugin.path, conventionalChangelog
-  opts = defaults {}, plugin.opts, DEFAULT
+  opts = defaults {}, plugin.opts.options, DEFAULT
   isFirstTime = !existsFile.sync opts.filename
 
   opts.infile = opts.filename


### PR DESCRIPTION
The `index.coffee` file had a critical bug on [line 22](https://github.com/bumped/bumped-changelog/blob/master/lib/index.coffee#L22) which prevented any plugin options being merged into the local options correctly.

As a result the `parseOptions` did not convert the user-defined options into cli arguments for `conventional-changelog-cli`.

Following the configuration as per the readme now works correctly:

```
plugins:
  postrelease:
    'Generating CHANGELOG file':
      plugin: 'bumped-changelog'
      options:
        preset: 'angular'
        filename: 'CHANGELOG.md'
```

Previously this would've resulted in `options` having been given to the CLI as `--options=[object Object]`.