### PR TITLE
Fixes the cross system cli pathing issues for Windows

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -5,7 +5,7 @@ defaults   = require 'lodash.defaults'
 existsFile = require 'exists-file'
 path       = require 'path'
 
-conventionalChangelog = 'node_modules/conventional-changelog-cli/cli.js'
+conventionalChangelog = 'conventional-changelog-cli/cli.js'
 
 DEFAULT =
   filename: 'CHANGELOG.md'
@@ -18,7 +18,7 @@ parseOptions = (opts) ->
       "--#{opt}#{flagValue}"
 
 module.exports = (bumped, plugin, cb) ->
-  changelog = path.resolve plugin.path, conventionalChangelog
+  changelog = path.resolve plugin.path, '..', conventionalChangelog
   opts = defaults {}, plugin.opts.options, DEFAULT
   isFirstTime = !existsFile.sync opts.filename
 

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-spawn      = require('child_process').spawn
+spawn      = require 'cross-spawn'
 defaults   = require 'lodash.defaults'
 existsFile = require 'exists-file'
 path       = require 'path'

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -5,7 +5,7 @@ defaults   = require 'lodash.defaults'
 existsFile = require 'exists-file'
 path       = require 'path'
 
-conventionalChangelog = 'conventional-changelog-cli/cli.js'
+conventionalChangelog = require.resolve 'conventional-changelog-cli/cli.js'
 
 DEFAULT =
   filename: 'CHANGELOG.md'
@@ -18,7 +18,7 @@ parseOptions = (opts) ->
       "--#{opt}#{flagValue}"
 
 module.exports = (bumped, plugin, cb) ->
-  changelog = path.resolve plugin.path, '..', conventionalChangelog
+  changelog = conventionalChangelog
   opts = defaults {}, plugin.opts.options, DEFAULT
   isFirstTime = !existsFile.sync opts.filename
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bumped-changelog",
   "description": "Auto generate a changelog file in each bump.",
   "homepage": "https://github.com/Bumped/bumped-changelog",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "main": "./index.js",
   "author": {
     "email": "josefrancisco.verdu@gmail.com",
@@ -26,8 +26,12 @@
   "dependencies": {
     "coffee-script": "~1.12.2",
     "conventional-changelog-cli": "~1.3.1",
+    "coffee-script": "~1.12.0",
     "exists-file": "~3.0.0",
     "lodash.defaults": "~4.2.0"
+  },
+  "peerDependencies": {
+    "conventional-changelog-cli": "~1.0"
   },
   "devDependencies": {
     "mocha": "latest",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "plugin"
   ],
   "dependencies": {
-    "coffee-script": "~1.12.2",
-    "conventional-changelog-cli": "~1.3.1",
     "coffee-script": "~1.12.0",
+    "conventional-changelog-cli": "~1.3.1",
+    "cross-spawn": "^5.1.0",
     "exists-file": "~3.0.0",
     "lodash.defaults": "~4.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "exists-file": "~3.0.0",
     "lodash.defaults": "~4.2.0"
   },
-  "peerDependencies": {
-    "conventional-changelog-cli": "~1.0"
-  },
   "devDependencies": {
     "mocha": "latest",
     "should": "latest"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bumped-changelog",
   "description": "Auto generate a changelog file in each bump.",
   "homepage": "https://github.com/Bumped/bumped-changelog",
-  "version": "0.4.0",
+  "version": "0.3.8",
   "main": "./index.js",
   "author": {
     "email": "josefrancisco.verdu@gmail.com",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "plugin"
   ],
   "dependencies": {
-    "coffee-script": "~1.12.0",
+    "coffee-script": "~1.12.2",
     "conventional-changelog-cli": "~1.3.1",
     "cross-spawn": "^5.1.0",
     "exists-file": "~3.0.0",


### PR DESCRIPTION
Hi @Kikobeats,

It's been a while but I've just had some time to look at this again and finally fixed the cross OS pathing issues we've been having (#18, #19).

The key was using `require.resolve 'conventional-changelog-cli/cli.js'` to get a system independent absolute path to the local `node_modules/conventional-changelog-cli/cli.js` file.

Once this was done, Windows was still throwing errors trying to execute the `child_process.spawn` command which was fixed by using `cross-spawn`.

As it stands, this PR here has been tested by myself on Mac OS X 10.11.6 and Windows 10 as fully working as expected.

Feel free to give it a spin and merge when ready or leave feedback for me to address :)

Oh and one more thing, I wasn't sure whether this warrants a `package.json` bump to `0.4.0` or if you'd rather just bump to `03.9` so I will leave it up to you to do the version bump as you see fit.

Hope this helps :)